### PR TITLE
[DEV] base-color 색상 지정

### DIFF
--- a/lib/Utils/Color.dart
+++ b/lib/Utils/Color.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class AppColor extends Color {
+  AppColor(super.value);
+
+  static const SocdocBlue = Color(0xFF182277);
+}


### PR DESCRIPTION
## Summary
base-color 색상 지정을 지정하였습니다.

## Description
- `lib/Utils/Color.dart`파일에 프로젝트 base color인 "0xFF182277"을 추가하였습니다.
- `SocdocBlue`로 사용하면 됩니다
<img width="115" alt="스크린샷 2023-11-07 오후 3 27 48" src="https://github.com/SOCDOC-CAU/SOCDOC-Flutter/assets/81398185/1f7eab09-0cc5-4491-a6c8-9693698564ec">
