### PR TITLE
[DEV] Flutter 병원 타입 구성

### DIFF
--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -3,6 +3,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 
 Future<void> tryAppleLogin() async {
   final appleProvider = AppleAuthProvider();
+  appleProvider.addScope('email');
   await FirebaseAuth.instance.signInWithProvider(appleProvider);
 }
 

--- a/lib/Utils/HospitalTypes.dart
+++ b/lib/Utils/HospitalTypes.dart
@@ -21,6 +21,7 @@ const List<HospitalItem> HospitalTypes = [
   HospitalItem(ko: "안과", en: "Ophthalmology"),
   HospitalItem(ko: "이비인후과", en: "Otolaryngology"),
   HospitalItem(ko: "비뇨기과", en: "Urology"),
+  HospitalItem(ko: "", en: ""),
   HospitalItem(ko: "재활의학과", en: "Rehabilitation Medicine"),
   HospitalItem(ko: "마취통증의학과", en: "Anesthesiology and Pain Medicine"),
   HospitalItem(ko: "영상의학과", en: "Radiology"),

--- a/lib/Utils/HospitalTypes.dart
+++ b/lib/Utils/HospitalTypes.dart
@@ -5,7 +5,7 @@ class HospitalItem {
   final String ko;
 }
 
-const List<HospitalItem> hospitalList = [
+const List<HospitalItem> HospitalTypes = [
   HospitalItem(ko: "전체", en: "All"),
   HospitalItem(ko: "내과", en: "Internal Medicine"),
   HospitalItem(ko: "소아청소년과", en: "Pediatrics"),

--- a/lib/Utils/HospitalTypes.dart
+++ b/lib/Utils/HospitalTypes.dart
@@ -1,0 +1,7 @@
+class HospitalItem {
+  const HospitalItem({required this.ko, required this.en});
+
+  final String en;
+  final String ko;
+}
+

--- a/lib/Utils/HospitalTypes.dart
+++ b/lib/Utils/HospitalTypes.dart
@@ -5,3 +5,26 @@ class HospitalItem {
   final String ko;
 }
 
+const List<HospitalItem> hospitalList = [
+  HospitalItem(ko: "전체", en: "All"),
+  HospitalItem(ko: "내과", en: "Internal Medicine"),
+  HospitalItem(ko: "소아청소년과", en: "Pediatrics"),
+  HospitalItem(ko: "신경과", en: "Neurology"),
+  HospitalItem(ko: "정신건강의학과", en: "Psychiatry"),
+  HospitalItem(ko: "피부과", en: "Dermatology"),
+  HospitalItem(ko: "외과", en: "Surgical"),
+  HospitalItem(ko: "흉부외과", en: "Thoracic Surgery"),
+  HospitalItem(ko: "정형외과", en: "Orthopedics"),
+  HospitalItem(ko: "신경외과", en: "Neurosurgery"),
+  HospitalItem(ko: "성형외과", en: "Plastic Surgery"),
+  HospitalItem(ko: "산부인과", en: "Obstetrics and Gynecology"),
+  HospitalItem(ko: "안과", en: "Ophthalmology"),
+  HospitalItem(ko: "이비인후과", en: "Otolaryngology"),
+  HospitalItem(ko: "비뇨기과", en: "Urology"),
+  HospitalItem(ko: "재활의학과", en: "Rehabilitation Medicine"),
+  HospitalItem(ko: "마취통증의학과", en: "Anesthesiology and Pain Medicine"),
+  HospitalItem(ko: "영상의학과", en: "Radiology"),
+  HospitalItem(ko: "가정의학과", en: "Family Medicine"),
+  HospitalItem(ko: "치과", en: "Dental"),
+  HospitalItem(ko: "구강악안면외과", en: "Oral Maxillofacial Surgery"),
+];


### PR DESCRIPTION
## Summary
병원 타입을 정의하기 위한 데이터클래스를 구성하였습니다.

## Description
- Util 내에 HospotalTypes 관련 코드를 추가 구성하였습니다.
- 19개 병원 과 분류에 대한 한국어와 영어 항목을 담은 List를 구성하였습니다. 0번 인덱스의 경우에는 `"전체"` 항목을 의미하며, 1번부터 19번 인덱스의 경우에는 공공API에서 제공하는 병원정보에 정의된 과 인덱스를 반영하였습니다.
- 본 Util을 사용하려는 경우, 상단에 `'package:socdoc_flutter/Utils/HospitalTypes.dart'`를 import한 뒤, `HospitalTypes[0].ko` 혹은 `HospitalTypes[12].en` 형식으로 접근해 문자열을 가져올 수 있습니다.
- 영어 번역의 경우, 파파고에 기반해 적용하였으며 문제가 있거나 더 좋은 단어가 있다면 알려주십쇼..