### PR TITLE
[FIX] Firebase Auth 관련 속성 업데이트

### DIFF
--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -3,6 +3,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 
 Future<void> tryAppleLogin() async {
   final appleProvider = AppleAuthProvider();
+  appleProvider.addScope('email');
   await FirebaseAuth.instance.signInWithProvider(appleProvider);
 }
 


### PR DESCRIPTION
## Summary
기존에 #11 에서 작업한 Firebase Auth 관련 속성을 업데이트하였습니다.

## Description
- 기존 작업 결과물의 경우, Android 및 iOS에서의 Google 로그인에는 별다른 문제가 없었으나, iOS 기기에서의 Apple ID 연동 로그인의 경우 Firebase Auth 상에 Identificator 값이 누락되는 문제가 있었습니다. 이를 해결하고자 Apple Login Provider의 속성값에 Email 관련 값을 추가로 정의하였습니다.