### PR TITLE
[DEV] Flutter 로그인 관련 API 연동

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -32,3 +32,5 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+
+*.lock

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,76 +5,83 @@ PODS:
   - AppAuth/Core (1.6.2)
   - AppAuth/ExternalUserAgent (1.6.2):
     - AppAuth/Core
-  - Firebase/Auth (10.16.0):
+  - Firebase/Auth (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.16.0)
-  - Firebase/CoreOnly (10.16.0):
-    - FirebaseCore (= 10.16.0)
-  - firebase_auth (4.12.1):
-    - Firebase/Auth (= 10.16.0)
+    - FirebaseAuth (~> 10.18.0)
+  - Firebase/CoreOnly (10.18.0):
+    - FirebaseCore (= 10.18.0)
+  - firebase_auth (4.15.0):
+    - Firebase/Auth (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_core (2.21.0):
-    - Firebase/CoreOnly (= 10.16.0)
+  - firebase_core (2.24.0):
+    - Firebase/CoreOnly (= 10.18.0)
     - Flutter
-  - FirebaseAppCheckInterop (10.17.0)
-  - FirebaseAuth (10.16.0):
-    - FirebaseAppCheckInterop (~> 10.0)
+  - FirebaseAppCheckInterop (10.18.0)
+  - FirebaseAuth (10.18.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseCore (10.16.0):
+  - FirebaseCore (10.18.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.17.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreInternal (10.18.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - Flutter (1.0.0)
+  - geolocator_apple (1.2.0):
+    - Flutter
   - google_maps_flutter_ios (0.0.1):
     - Flutter
-    - GoogleMaps (< 8.0)
+    - GoogleMaps (< 9.0)
   - google_sign_in_ios (0.0.1):
     - Flutter
-    - GoogleSignIn (~> 6.2)
+    - GoogleSignIn (~> 7.0)
   - GoogleMaps (5.2.0):
     - GoogleMaps/Maps (= 5.2.0)
   - GoogleMaps/Base (5.2.0)
   - GoogleMaps/Maps (5.2.0):
     - GoogleMaps/Base
-  - GoogleSignIn (6.2.4):
+  - GoogleSignIn (7.0.0):
     - AppAuth (~> 1.5)
-    - GTMAppAuth (~> 1.3)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.6):
+    - GTMAppAuth (< 3.0, >= 1.3)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
+  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.6):
+  - GoogleUtilities/Environment (7.12.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.6):
+  - GoogleUtilities/Logger (7.12.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.11.6):
+  - GoogleUtilities/Network (7.12.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.6)"
-  - GoogleUtilities/Reachability (7.11.6):
+  - "GoogleUtilities/NSData+zlib (7.12.0)"
+  - GoogleUtilities/Reachability (7.12.0):
     - GoogleUtilities/Logger
-  - GTMAppAuth (1.3.1):
+  - GTMAppAuth (2.0.0):
     - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (2.3.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.5)
+  - GTMSessionFetcher/Core (3.2.0)
   - PromisesObjC (2.3.1)
   - RecaptchaInterop (100.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -99,30 +106,36 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/ios"
   google_maps_flutter_ios:
     :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  Firebase: 25899099b77d255a636e3579c3d9dce10ec150d5
-  firebase_auth: ff474dcf17bee5762106162e0791433024890ada
-  firebase_core: 68027ba03585e3efe1608e35d3ab2777a64eabe9
-  FirebaseAppCheckInterop: 534d033d8d0436b4ab066a8205013d271e18a2b9
-  FirebaseAuth: 3862d87d4d58deff08f705d471896a2f66e8bbf0
-  FirebaseCore: 65a801af84cca84361ef9eac3fd868656968a53b
-  FirebaseCoreInternal: 2cf9202e226e3f78d2bf6d56c472686b935bfb7f
+  Firebase: 414ad272f8d02dfbf12662a9d43f4bba9bec2a06
+  firebase_auth: 02d1a6340f81020cc302fb8fea8518908c546cec
+  firebase_core: f802c5c1f6caff9b8d38b591a36e7b25f8878936
+  FirebaseAppCheckInterop: 3cd914842ba46f4304050874cd284de82f154ffd
+  FirebaseAuth: 12314b438fa76048540c8fb86d6cfc9e08595176
+  FirebaseCore: 2322423314d92f946219c8791674d2f3345b598f
+  FirebaseCoreInternal: 8eb002e564b533bdcf1ba011f33f2b5c10e2ed4a
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  google_maps_flutter_ios: abdac20d6ce8931f6ebc5f46616df241bfaa2cfd
-  google_sign_in_ios: 1256ff9d941db546373826966720b0c24804bcdd
+  geolocator_apple: cc556e6844d508c95df1e87e3ea6fa4e58c50401
+  google_maps_flutter_ios: 590249c67f34f422122c232f2a626192adbc78ee
+  google_sign_in_ios: 8115e3fbe097e6509beb819ed602d47369d9011f
   GoogleMaps: 025272d5876d3b32604e5c080dc25eaf68764693
-  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: 202e7a9f5128accd11160fb9c19612de1911aa19
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
+  GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
+  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
+  GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
+  GTMSessionFetcher: 41b9ef0b4c08a6db4b7eb51a21ae5183ec99a2c8
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 

--- a/lib/Pages/LoginPage.dart
+++ b/lib/Pages/LoginPage.dart
@@ -60,6 +60,7 @@ class _LoginPageState extends State<LoginPage> {
         if(user != null && socdocApp != null){
           socdocApp!.setState(() {
             socdocApp!.isLoggedIn = true;
+            Navigator.pop(context);
           });
         }else if(mounted){
           setState(() {

--- a/lib/Pages/LoginPage.dart
+++ b/lib/Pages/LoginPage.dart
@@ -86,7 +86,7 @@ class _LoginButtons extends StatelessWidget {
               Buttons.google,
               text: "Sign In with Google",
               onPressed: () {
-                tryGoogleLogin();
+                tryLogin(0);
               }
             )
           ),
@@ -99,7 +99,7 @@ class _LoginButtons extends StatelessWidget {
               Buttons.apple,
               text: "Sign In with Apple",
               onPressed: () {
-                tryAppleLogin();
+                tryLogin(1);
               }
             )
           ),

--- a/lib/Pages/MainSubPages/HomePage.dart
+++ b/lib/Pages/MainSubPages/HomePage.dart
@@ -34,7 +34,7 @@ class _HomePageState extends State<HomePage> {
       setState(() {
         selectedTileIndices = storedIndices.map((index) => int.parse(index)).toList();
       });
-    }else{
+    }else if(mounted){
       setState(() {
         selectedTileIndices = [1,5,8,12];
       });

--- a/lib/Pages/MainSubPages/HomePage.dart
+++ b/lib/Pages/MainSubPages/HomePage.dart
@@ -30,7 +30,7 @@ class _HomePageState extends State<HomePage> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     List<String>? storedIndices = prefs.getStringList('selectedIndices');
 
-    if (storedIndices != null && storedIndices.length == 4) {
+    if (storedIndices != null && storedIndices.length == 4 && mounted) {
       setState(() {
         selectedTileIndices = storedIndices.map((index) => int.parse(index)).toList();
       });

--- a/lib/Pages/MainSubPages/SettingPage.dart
+++ b/lib/Pages/MainSubPages/SettingPage.dart
@@ -24,7 +24,7 @@ class SettingPage extends StatelessWidget {
             SizedBox(height: 20.0),
             MyPageList("내 리뷰 보기", Icons.rate_review_outlined),
             MyReviewList(),
-            BuildTextButton("로그아웃", () => tryFirebaseLogout(socdocApp)),
+            BuildTextButton("로그아웃", () => _showLogoutDialog(socdocApp, context)),
             BuildTextButton("회원 탈퇴", () => tryFirebaseDeleteUser(socdocApp)),
           ],
         ),
@@ -290,7 +290,41 @@ class SettingPage extends StatelessWidget {
     );
   }
 
-  void tryFirebaseLogout(SocdocAppState socdocApp) async {
+  Future<void> _showLogoutDialog(SocdocAppState socdocApp, BuildContext context) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('로그아웃'),
+          content: const SingleChildScrollView(
+            child: ListBody(
+              children: [
+                Text('정말 로그아웃 하시겠습니까?'),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('확인'),
+              onPressed: () {
+                _tryFirebaseLogout(socdocApp);
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _tryFirebaseLogout(SocdocAppState socdocApp) async {
     if (await tryLogout()) {
       socdocApp.setState(() {
         socdocApp.isLoggedIn = false;

--- a/lib/Pages/MainSubPages/SettingPage.dart
+++ b/lib/Pages/MainSubPages/SettingPage.dart
@@ -25,7 +25,7 @@ class SettingPage extends StatelessWidget {
             MyPageList("내 리뷰 보기", Icons.rate_review_outlined),
             MyReviewList(),
             BuildTextButton("로그아웃", () => _showLogoutDialog(socdocApp, context)),
-            BuildTextButton("회원 탈퇴", () => tryFirebaseDeleteUser(socdocApp)),
+            BuildTextButton("회원 탈퇴", () => _showDeleteUserDialog(socdocApp, context)),
           ],
         ),
       ),
@@ -324,6 +324,40 @@ class SettingPage extends StatelessWidget {
     );
   }
 
+  Future<void> _showDeleteUserDialog(SocdocAppState socdocApp, BuildContext context) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('회원 탈퇴'),
+          content: const SingleChildScrollView(
+            child: ListBody(
+              children: [
+                Text('정말 탈퇴 하시겠습니까?'),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('확인'),
+              onPressed: () {
+                _tryFirebaseDeleteUser(socdocApp);
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   void _tryFirebaseLogout(SocdocAppState socdocApp) async {
     if (await tryLogout()) {
       socdocApp.setState(() {
@@ -332,7 +366,7 @@ class SettingPage extends StatelessWidget {
     }
   }
 
-  void tryFirebaseDeleteUser(SocdocAppState socdocApp) async {
+  void _tryFirebaseDeleteUser(SocdocAppState socdocApp) async {
     if (await tryDeleteUser()) {
       socdocApp.setState(() {
         socdocApp.isLoggedIn = false;

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -1,13 +1,16 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:http/http.dart' as http;
 
-Future<void> tryAppleLogin() async {
+Future<String?> tryAppleLogin() async {
   final appleProvider = AppleAuthProvider();
   appleProvider.addScope('email');
   await FirebaseAuth.instance.signInWithProvider(appleProvider);
+
+  return await FirebaseAuth.instance.currentUser!.getIdToken();
 }
 
-Future<void> tryGoogleLogin() async {
+Future<String?> tryGoogleLogin() async {
   final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
   final GoogleSignInAuthentication? googleAuth = await googleUser?.authentication;
   final credential = GoogleAuthProvider.credential(
@@ -15,10 +18,17 @@ Future<void> tryGoogleLogin() async {
     idToken: googleAuth?.idToken,
   );
   await FirebaseAuth.instance.signInWithCredential(credential);
+
+  return await FirebaseAuth.instance.currentUser!.getIdToken();
 }
 
 Future<void> tryLogin(var type) async {
-  type == 0 ? tryGoogleLogin() : tryAppleLogin();
+  (type == 0 ? tryGoogleLogin() : tryAppleLogin()).then((userToken) => {
+    http.post(Uri.parse("https://socdoc.dev-lr.com/api/user/login"),
+      headers: {
+        "authToken": userToken!
+      })
+  });
 }
 
 Future<bool> tryLogout() async {

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -17,6 +17,10 @@ Future<void> tryGoogleLogin() async {
   await FirebaseAuth.instance.signInWithCredential(credential);
 }
 
+Future<void> tryLogin(var type) async {
+  type == 0 ? tryAppleLogin() : tryGoogleLogin();
+}
+
 Future<bool> tryLogout() async {
   await FirebaseAuth.instance.signOut();
   return (FirebaseAuth.instance.currentUser == null);

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -38,8 +38,9 @@ Future<bool> tryLogout() async {
 
 Future<bool> tryDeleteUser() async {
   if(FirebaseAuth.instance.currentUser != null){
-    await FirebaseAuth.instance.currentUser!.delete();
-    return tryLogout();
+    return http.delete(
+      Uri.parse("https://socdoc.dev-lr.com/api/user?userId=${FirebaseAuth.instance.currentUser!.uid}")
+    ).then((value) => tryLogout());
   }
 
   return false;

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -18,7 +18,7 @@ Future<void> tryGoogleLogin() async {
 }
 
 Future<void> tryLogin(var type) async {
-  type == 0 ? tryAppleLogin() : tryGoogleLogin();
+  type == 0 ? tryGoogleLogin() : tryAppleLogin();
 }
 
 Future<bool> tryLogout() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   shared_preferences: ^2.2.2
   google_maps_flutter: ^2.5.0
   geolocator: ^10.1.0
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
로그인 관련 기능에 API를 연동하였습니다.

## Description
- API 연동을 위해 `http` 패키지의 Dependency를 추가하였습니다.
- `AuthUtil` 내 로그인 및 탈퇴 함수에서 Back-End API를 호출하도록 연동하였습니다. 이 과정에서 `Auth Token` 값과 `User ID`의 전달을 위해 약간의 로직 변경이 있었습니다.
- `MainPage`에서 `setState(()=>{})` 호출 시 일부 과정에서 Widget Mount 경고가 발생하던 문제를 해결하였습니다.
- `SettingPage`에서 로그아웃 및 탈퇴 버튼 클릭 시, 곧바로 함수를 호출하지 않고 Alert Dialog를 통해 의사를 확인하도록 하였습니다.
- `OnboardingPage`에서 `LoginPage`를 `Navigator.push()`한 이후, 정상적으로 `MainPage`에 돌아가지 못하던 문제를 해결하였습니다.