### PR TITLE
[DEV] Flutter 주소지 변경 관련 API 연동 및 OnBoardingPage 이슈 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ lib/firebase_options.dart
 *.lock
 
 ApiKey.swift
+
+.env

--- a/lib/Pages/LoginPage.dart
+++ b/lib/Pages/LoginPage.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:sign_in_button/sign_in_button.dart';
+import 'package:socdoc_flutter/Pages/OnBoardingPage.dart';
 
 import 'package:socdoc_flutter/Utils/AuthUtil.dart';
 
@@ -60,11 +61,11 @@ class _LoginPageState extends State<LoginPage> {
         if(user != null && socdocApp != null){
           socdocApp!.setState(() {
             socdocApp!.isLoggedIn = true;
-            Navigator.pop(context);
           });
         }else if(mounted){
           setState(() {
             _isLoginNeeded = true;
+            Navigator.push(context, MaterialPageRoute(builder: (context) => OnBoardingPage()));
           });
         }
       });

--- a/lib/Pages/MainSubPages/MyAddress.dart
+++ b/lib/Pages/MainSubPages/MyAddress.dart
@@ -15,11 +15,3 @@ class MyAddress extends StatelessWidget {
     );
   }
 }
-
-void main() {
-  runApp(
-    MaterialApp(
-      home: MyAddress(),
-    ),
-  );
-}

--- a/lib/Pages/MainSubPages/SettingAddressPage.dart
+++ b/lib/Pages/MainSubPages/SettingAddressPage.dart
@@ -22,9 +22,14 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
   var curAddress2 = "동작구";
 
   @override
-  Widget build(BuildContext context) {
-    _determinePosition();
+  void initState() {
+    super.initState();
 
+    _determinePosition();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('SettingAddressPage'),
@@ -38,7 +43,13 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
       body: SafeArea(
         child: Column(
           children: [
-            const Text("지도를 움직여 위치를 선택해주세요."),
+            const Text(
+              "지도를 움직여 위치를 선택해주세요.",
+              style: TextStyle(fontSize: 20.0),
+            ),
+            const SizedBox(height: 5.0),
+            CurrentAddress(curAddress1: curAddress1, curAddress2: curAddress2),
+            const SizedBox(height: 10.0),
             Expanded(
               child: GoogleMap(
                 mapType: MapType.normal,
@@ -60,8 +71,11 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
                       "Authorization": "KakaoAK ${dotenv.env['KAKAO_API_KEY']}"
                   }).then((res) {
                     var resJson = jsonDecode(res.body);
-                    curAddress1 = resJson["documents"][0]["region_1depth_name"];
-                    curAddress2 = resJson["documents"][0]["region_2depth_name"];
+
+                    setState(() {
+                      curAddress1 = resJson["documents"][0]["region_1depth_name"];
+                      curAddress2 = resJson["documents"][0]["region_2depth_name"];
+                    });
                   });
                 },
               )
@@ -119,5 +133,25 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
 
     final GoogleMapController controller = await _controller.future;
     await controller.animateCamera(CameraUpdate.newCameraPosition(newCoord));
+  }
+}
+
+class CurrentAddress extends StatefulWidget {
+  const CurrentAddress({super.key, required this.curAddress1, required this.curAddress2});
+
+  final curAddress1;
+  final curAddress2;
+
+  @override
+  State<StatefulWidget> createState() => _CurrentAddressState();
+}
+
+class _CurrentAddressState extends State<CurrentAddress> {
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      "${widget.curAddress1} ${widget.curAddress2}",
+      style: const TextStyle(fontSize: 20.0),
+    );
   }
 }

--- a/lib/Pages/MainSubPages/SettingAddressPage.dart
+++ b/lib/Pages/MainSubPages/SettingAddressPage.dart
@@ -1,17 +1,85 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
-class SettingAddressPage extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class SettingAddressPage extends StatefulWidget {
   const SettingAddressPage({Key? key}) : super(key: key);
 
   @override
+  State<StatefulWidget> createState() => _SettingAddressPageState();
+}
+
+class _SettingAddressPageState extends State<SettingAddressPage> {
+  final Completer<GoogleMapController> _controller = Completer<GoogleMapController>();
+
+  static const CameraPosition initCoord = CameraPosition(
+    target: LatLng(37.4905987, 126.9441426),
+    zoom: 17,
+  );
+
+  @override
   Widget build(BuildContext context) {
+    _determinePosition();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('SettingAddressPage'),
       ),
-      body: const Center(
-        child: Text('우리 동네 수정 페이지'),
-      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            const Text("지도를 움직여 위치를 선택해주세요."),
+            Expanded(
+              child: GoogleMap(
+                mapType: MapType.normal,
+                initialCameraPosition: initCoord,
+                onMapCreated: (GoogleMapController controller) {
+                  _controller.complete(controller);
+                }
+              )
+            )
+          ],
+        ),
+      )
     );
+  }
+
+  Future<void> _determinePosition() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return Future.error('Location services are disabled.');
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return Future.error('Location permissions are denied');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      return Future.error(
+          'Location permissions are permanently denied, we cannot request permissions.');
+    }
+
+    await Geolocator.getCurrentPosition().then((cur) => {
+      _moveCamera(cur.latitude, cur.longitude)
+    });
+  }
+
+  Future<void> _moveCamera(lat, lng) async {
+    CameraPosition newCoord = CameraPosition(
+      target: LatLng(lat, lng),
+      zoom: 17,
+    );
+
+    final GoogleMapController controller = await _controller.future;
+    await controller.animateCamera(CameraUpdate.newCameraPosition(newCoord));
   }
 }

--- a/lib/Pages/MainSubPages/SettingAddressPage.dart
+++ b/lib/Pages/MainSubPages/SettingAddressPage.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class MyAddress extends StatelessWidget {
-  const MyAddress({Key? key}) : super(key: key);
+class SettingAddressPage extends StatelessWidget {
+  const SettingAddressPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('My Address'),
+        title: const Text('SettingAddressPage'),
       ),
       body: const Center(
         child: Text('우리 동네 수정 페이지'),

--- a/lib/Pages/MainSubPages/SettingAddressPage.dart
+++ b/lib/Pages/MainSubPages/SettingAddressPage.dart
@@ -6,6 +6,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
+import 'package:socdoc_flutter/Utils/AuthUtil.dart';
 
 class SettingAddressPage extends StatefulWidget {
   const SettingAddressPage({Key? key}) : super(key: key);
@@ -27,6 +28,12 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('SettingAddressPage'),
+        actions: [
+          IconButton(
+            onPressed: (){
+              _uploadData().then((value) => Navigator.pop(context));
+            }, icon: const Icon(Icons.check))
+        ],
       ),
       body: SafeArea(
         child: Column(
@@ -63,6 +70,18 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
         ),
       )
     );
+  }
+
+  Future<void> _uploadData() async {
+    http.put(Uri.parse("https://socdoc.dev-lr.com/api/user/update/address"),
+      headers: {
+        "content-type": "application/json"
+      },
+      body: jsonEncode({
+        "address1": curAddress1,
+        "address2": curAddress2,
+        "userId": getUserID()
+      }));
   }
 
   Future<void> _determinePosition() async {

--- a/lib/Pages/MainSubPages/SettingAddressPage.dart
+++ b/lib/Pages/MainSubPages/SettingAddressPage.dart
@@ -139,8 +139,8 @@ class _SettingAddressPageState extends State<SettingAddressPage> {
 class CurrentAddress extends StatefulWidget {
   const CurrentAddress({super.key, required this.curAddress1, required this.curAddress2});
 
-  final curAddress1;
-  final curAddress2;
+  final String curAddress1;
+  final String curAddress2;
 
   @override
   State<StatefulWidget> createState() => _CurrentAddressState();

--- a/lib/Pages/MainSubPages/SettingPage.dart
+++ b/lib/Pages/MainSubPages/SettingPage.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:socdoc_flutter/Utils/AuthUtil.dart';
 import 'package:socdoc_flutter/main.dart';
 import 'package:socdoc_flutter/Utils/Color.dart';
-import 'package:socdoc_flutter/Pages/MainSubPages/MyAddress.dart';
+import 'package:socdoc_flutter/Pages/MainSubPages/SettingAddressPage.dart';
 
 class SettingPage extends StatelessWidget {
   const SettingPage({Key? key});
@@ -75,7 +75,7 @@ class SettingPage extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => MyAddress(),
+                            builder: (context) => SettingAddressPage(),
                           ),
                         );
                       },

--- a/lib/Pages/OnBoardingPage.dart
+++ b/lib/Pages/OnBoardingPage.dart
@@ -93,10 +93,7 @@ class _OnBoardingPageState extends State<OnBoardingPage> {
                 padding: const EdgeInsets.all(20.0),
                 child: TextButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => LoginPage()),
-                    );
+                    Navigator.pop(context);
                   },
                   child: Text(
                     (isLastPage == true)

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -2,6 +2,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 
+Future<String?> getUserID() async {
+  return await FirebaseAuth.instance.currentUser!.uid;
+}
+
 Future<String?> getUserToken() async {
   return await FirebaseAuth.instance.currentUser!.getIdToken();
 }

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -2,8 +2,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 
-Future<String?> getUserID() async {
-  return await FirebaseAuth.instance.currentUser!.uid;
+String getUserID() {
+  return FirebaseAuth.instance.currentUser!.uid;
 }
 
 Future<String?> getUserToken() async {

--- a/lib/Utils/AuthUtil.dart
+++ b/lib/Utils/AuthUtil.dart
@@ -2,6 +2,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 
+Future<String?> getUserToken() async {
+  return await FirebaseAuth.instance.currentUser!.getIdToken();
+}
+
 Future<String?> tryAppleLogin() async {
   final appleProvider = AppleAuthProvider();
   appleProvider.addScope('email');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:socdoc_flutter/Pages/LoginPage.dart';
 import 'package:socdoc_flutter/Pages/MainPage.dart';
-import 'package:socdoc_flutter/Pages/OnBoardingPage.dart';
 
 void main() {
   runApp(const SocdocApp());
@@ -25,7 +25,7 @@ class SocdocAppState extends State<SocdocApp> {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true
       ),
-      home: isLoggedIn ? MainPage() : OnBoardingPage(),
+      home: isLoggedIn ? MainPage() : LoginPage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:socdoc_flutter/Pages/LoginPage.dart';
 import 'package:socdoc_flutter/Pages/MainPage.dart';
 
-void main() {
+void main() async {
+  await dotenv.load(fileName: ".env");
   runApp(const SocdocApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   google_maps_flutter: ^2.5.0
   geolocator: ^10.1.0
   http: ^1.1.0
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+   - .env
    - assets/
    - assets/hospital/
    - assets/images/


### PR DESCRIPTION
## Summary
주소지 변경 관련 기능에 API를 연동하였습니다.

## Description
- 기존 #35 이후 OnBoardingPage가 무한으로 호출되던 문제를 해결하였습니다.
- 주소지 변경을 위한 Page의 이름을 기존 `MyAddress`에서 `SettingAddressPage`로 변경하였습니다.
- `SettingAddressPage`에 Google Map 렌더링을 적용하고, 현위치를 통해 기본 MapView를 구성하도록 하였습니다.
- MapView를 이동할 경우, `onCameraIdle` 리스너를 통해 이동이 완료된 시점의 좌표를 확인하고, 해당 좌표를 Kakao Local API에 호출하여 행정구역 주소 정보를 조회합니다. 이 과정에서 API 키의 관리를 위한 `flutter_dotenv` 패키지가 추가되었습니다.
- 이후, 완료 버튼을 클릭할 경우, 현재 MapView의 행정구역 주소 정보를 API로 전송합니다.

<img width="40%" src="https://github.com/SOCDOC-CAU/SOCDOC-Flutter/assets/12806229/831a7bc9-a5dd-4946-a4b0-28af69ec8eec" />